### PR TITLE
change fopen to fopen_s

### DIFF
--- a/bmpread.c
+++ b/bmpread.c
@@ -916,9 +916,9 @@ int bmpread(const char * bmp_file, unsigned int flags, bmpread_t * p_bmp_out)
 
         ctx.flags = flags;
 
-        if(!fopen_s(&ctx.fp, bmp_file, "rb")) break;
-        if(!Validate(&ctx))                   break;
-        if(!Decode(&ctx))                     break;
+        if(fopen_s(&ctx.fp, bmp_file, "rb")) break;
+        if(!Validate(&ctx))                  break;
+        if(!Decode(&ctx))                    break;
 
         /* Finally, make sure we can stuff these into ints.  I feel like this
          * is slightly justified by how it keeps the header definition dead

--- a/bmpread.c
+++ b/bmpread.c
@@ -916,7 +916,7 @@ int bmpread(const char * bmp_file, unsigned int flags, bmpread_t * p_bmp_out)
 
         ctx.flags = flags;
 
-        if(!(ctx.fp = fopen(bmp_file, "rb"))) break;
+        if(!fopen_s(&ctx.fp, bmp_file, "rb")) break;
         if(!Validate(&ctx))                   break;
         if(!Decode(&ctx))                     break;
 


### PR DESCRIPTION
fopen causes a compiler warning in Visual Studio 2017 which is fixed with this pull request